### PR TITLE
Automobile Nodes Enum Fix

### DIFF
--- a/src/vehicles/Automobile.h
+++ b/src/vehicles/Automobile.h
@@ -8,7 +8,7 @@ class CObject;
 
 enum eCarNodes
 {
-	CAR_WHEEL_RF = 1,
+	CAR_WHEEL_RF = 0,
 	CAR_WHEEL_RM,
 	CAR_WHEEL_RB,
 	CAR_WHEEL_LF,


### PR DESCRIPTION
Changes enum eCarNodes to start at 0 so that NUM_CAR_NODES is correct. Since the enum started at 1, NUM_CAR_NODES was 1 greater than it should be.
Lead to errors when running this line in Automobile.cpp
CAutomobile::SetupModelNodes(void)
{
	int i;
	for(i = 0; i < NUM_CAR_NODES; i++)
		m_aCarNodes[i] = nil;
	CClumpModelInfo::FillFrameArray(GetClump(), m_aCarNodes);
}

As long as it's not linux/cross-platform skeleton/compatibility layer, all of the code on the repo that's not behind a preprocessor condition(like FIX_BUGS) are **completely** reversed code from original binaries.  

We **don't** accept custom codes, as long as it's not wrapped via preprocessor conditions, or it's linux/cross-platform skeleton/compatibility layer.

We accept only these kinds of PRs;

- A new feature that exists in at least one of the GTAs (if it wasn't in III/VC then it doesn't have to be decompilation)  
- Game, UI or UX bug fixes (if it's a fix to R* code, it should be behind FIX_BUGS)
- Platform-specific and/or unused code that's not been reversed yet
- Makes reversed code more understandable/accurate, as in "which code would produce this assembly".
- A new cross-platform skeleton/compatibility layer, or improvements to them
- Translation fixes, for languages R* supported/outsourced
- Code that increase maintainability
