### PR TITLE
Update build-switch.yml

### DIFF
--- a/.github/workflows/build-switch.yml
+++ b/.github/workflows/build-switch.yml
@@ -1,6 +1,7 @@
 
 name: reVC cmake devkitA64 (Nintendo Switch)
 on:
+workflow_dispatch:
   pull_request:
   push:
   release:


### PR DESCRIPTION
As long as it's not linux/cross-platform skeleton/compatibility layer, all of the code on the repo that's not behind a preprocessor condition(like FIX_BUGS) are **completely** reversed code from original binaries.  

We **don't** accept custom codes, as long as it's not wrapped via preprocessor conditions, or it's linux/cross-platform skeleton/compatibility layer.

We accept only these kinds of PRs;

- A new feature that exists in at least one of the GTAs (if it wasn't in III/VC then it doesn't have to be decompilation)  
- Game, UI or UX bug fixes (if it's a fix to R* code, it should be behind FIX_BUGS)
- Platform-specific and/or unused code that's not been reversed yet
- Makes reversed code more understandable/accurate, as in "which code would produce this assembly".
- A new cross-platform skeleton/compatibility layer, or improvements to them
- Translation fixes, for languages R* supported/outsourced
- Code that increase maintainability
